### PR TITLE
Document Python 3.11 upgrade readiness and remove deprecated NumPy alias

### DIFF
--- a/clpipe/tabularutils/codebook.py
+++ b/clpipe/tabularutils/codebook.py
@@ -7,6 +7,7 @@ from clpipe.error_handler import exception_handler
 import numpy as np
 import os
 import click
+from pandas.api.types import is_float_dtype, is_integer_dtype, is_object_dtype
 
 
 @click.command()
@@ -56,10 +57,10 @@ def create_json_codebook(config_file=None, file_path=None, debug=False):
 
     data = pd.read_csv(file_path, delimiter=",")
 
-    possible_cat = [np.int64, np.object, np.float64]
+    dtype_checks = (is_integer_dtype, is_object_dtype, is_float_dtype)
     data_dict = {}
     for column in data.columns:
-        if data.dtypes[column] in possible_cat:
+        if any(check(data.dtypes[column]) for check in dtype_checks):
             if len(data[column].unique()) <= 12:
                 levels_dict = dict(
                     zip(

--- a/docs/python311-compatibility.md
+++ b/docs/python311-compatibility.md
@@ -25,3 +25,31 @@ At the time of writing, the scan reports the following blockers:
 
 Upgrading these packages (and re-testing any downstream tools that depend on
 them) is a prerequisite for building `clpipe` on Python 3.11 or newer.
+
+## Upgrade readiness assessment
+
+The repository already exercises these libraries in a mostly modern way, so
+only limited code changes were required to become compatible with the Python
+3.11-capable release lines:
+
+- **NumPy** – the only deprecated construct discovered during the audit was the
+  legacy `np.object` alias that NumPy removed in 1.24.  The code path in
+  `clpipe/tabularutils/codebook.py` now relies on pandas dtype helpers instead,
+  which keeps the behaviour and remains compatible with both old and new NumPy
+  releases.【F:clpipe/tabularutils/codebook.py†L1-L70】
+- **pandas** – all tabular helpers use `read_csv`, `read_table`, and DataFrame
+  concatenation APIs that are stable in pandas 1.5+.  No usage of APIs removed
+  in recent pandas versions (e.g. `Panel`, `.ix`, or `.append`) was found during
+  the repository scan.【F:clpipe/beta_series_reg.py†L1-L120】【F:clpipe/legacy_postprocess.py†L1-L220】
+- **SciPy** – existing imports (`scipy.signal`, `scipy.sparse.spdiags`, and
+  `scipy.linalg.toeplitz`) are still present in SciPy 1.9+, so raising the pin
+  should not require additional code changes.  These routines are used in
+  `clpipe/beta_series_reg.py` and `clpipe/postprocutils/utils.py` without
+  deprecated arguments.【F:clpipe/beta_series_reg.py†L1-L120】【F:clpipe/postprocutils/utils.py†L150-L210】
+- **Matplotlib** – the project only imports `matplotlib.pyplot` for figure
+  generation in the beta-series regression script and in tests.  Those call
+  sites rely on plotting primitives that have not changed between 3.5 and 3.6,
+  so updating the pin is expected to be safe.【F:clpipe/beta_series_reg.py†L1-L120】【F:tests/conftest.py†L70-L110】
+
+After bumping the dependency pins in `clpipe/config/package.py`, re-run the
+test suite (`pytest`) to confirm the newer versions work end-to-end.


### PR DESCRIPTION
## Summary
- replace the deprecated `np.object` dtype check in `codebook.py` with pandas helpers that work on NumPy 1.24+
- expand the Python 3.11 compatibility note with an assessment of the NumPy, pandas, SciPy, and Matplotlib upgrade impact

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'bids')*

------
https://chatgpt.com/codex/tasks/task_e_68efb6c73ed8832c8be9d1dd7e9a5c42